### PR TITLE
#2 - Implement an annotation visitor mechanism

### DIFF
--- a/common/src/main/java/com/kakoo/foundation/common/exception/AbstractCheckedException.java
+++ b/common/src/main/java/com/kakoo/foundation/common/exception/AbstractCheckedException.java
@@ -59,7 +59,7 @@ public abstract class AbstractCheckedException extends Exception
      */
     public AbstractCheckedException(final Enum<? extends IBundle> key)
     {
-        super(ResourceBundleManager.getMessage(key));
+        super(ResourceBundleManager.get(key));
     }
 
     /**
@@ -103,7 +103,7 @@ public abstract class AbstractCheckedException extends Exception
     public AbstractCheckedException(final Enum<?> key, final Object... parameters)
     {
         super(key instanceof IBundle
-                ? MessageFormat.format(ResourceBundleManager.getMessage((Enum<? extends IBundle>) key), parameters)
+                ? MessageFormat.format(ResourceBundleManager.get((Enum<? extends IBundle>) key), parameters)
                 : MessageFormat.format(((IException) key).getMessage(), parameters));
 
         // Do we have an exception in the parameter list?

--- a/common/src/main/java/com/kakoo/foundation/common/exception/AbstractUncheckedException.java
+++ b/common/src/main/java/com/kakoo/foundation/common/exception/AbstractUncheckedException.java
@@ -55,7 +55,7 @@ public abstract class AbstractUncheckedException extends RuntimeException
      */
     public AbstractUncheckedException(final Enum<? extends IBundle> key)
     {
-        super(ResourceBundleManager.getMessage(key));
+        super(ResourceBundleManager.get(key));
     }
 
     /**
@@ -68,7 +68,7 @@ public abstract class AbstractUncheckedException extends RuntimeException
     public AbstractUncheckedException(final Enum<?> key, final Object... parameters)
     {
         super(key instanceof IBundle
-                ? MessageFormat.format(ResourceBundleManager.getMessage((Enum<? extends IBundle>) key), parameters)
+                ? MessageFormat.format(ResourceBundleManager.get((Enum<? extends IBundle>) key), parameters)
                 : MessageFormat.format(((IException) key).getMessage(), parameters));
 
         // Do we have an exception in the parameter list?

--- a/common/src/main/java/com/kakoo/foundation/common/resource/bundle/KakooFoundationCommonBundle.java
+++ b/common/src/main/java/com/kakoo/foundation/common/resource/bundle/KakooFoundationCommonBundle.java
@@ -12,6 +12,7 @@
 package com.kakoo.foundation.common.resource.bundle;
 
 import com.kakoo.foundation.common.resource.bundle.annotation.Bundle;
+import lombok.Getter;
 
 /**
  * Enumeration of the resource bundle keys of the <b>Kakoo Common</b> component. Each enumerated value maps to a key
@@ -21,7 +22,7 @@ import com.kakoo.foundation.common.resource.bundle.annotation.Bundle;
  * @version 1.0.0
  */
 @SuppressWarnings("nls")
-@Bundle(file="bundle/kakoo-foundation-common", root="kakoo-foundation-common.", priority = 1) // This one must be loaded first!
+@Bundle(file="i18n/kakoo-foundation-common", root="kakoo-foundation-common.", priority = 1) // This one must be loaded first!
 public enum KakooFoundationCommonBundle implements IBundle
 {
     /*
@@ -37,6 +38,11 @@ public enum KakooFoundationCommonBundle implements IBundle
      * A dummy test message for the language.
      */
     TEST_DUMMY_LANGUAGE("test.dummy.language"),
+
+    /**
+     * A dummy test formatted message.
+     */
+    TEST_DUMMY_MESSAGE_FORMATTED("test.dummy.message.formatted"),
 
     /*
      * ---------- Resource.Bundle.* ----------
@@ -95,6 +101,7 @@ public enum KakooFoundationCommonBundle implements IBundle
     /**
      * Resource bundle key.
      */
+    @Getter
     private final String key;
 
     /**
@@ -108,21 +115,9 @@ public enum KakooFoundationCommonBundle implements IBundle
     }
 
     @Override
-    public final String getKey()
-    {
-        Bundle annotation = this.getClass().getAnnotation(Bundle.class);
-        if (annotation != null)
-        {
-            return annotation.root().endsWith(".") ? annotation.root() + key : annotation.root() + "." + key;
-        }
-
-        return key;
-    }
-
-    @Override
     public final String getValue()
     {
-        return ResourceBundleManager.getMessage(this);
+        return ResourceBundleManager.get(this);
     }
 }
 

--- a/common/src/main/java/com/kakoo/foundation/common/resource/bundle/StatusType.java
+++ b/common/src/main/java/com/kakoo/foundation/common/resource/bundle/StatusType.java
@@ -37,5 +37,10 @@ public enum StatusType
     /**
      * Refreshing status.
      */
-    REFRESHING
+    REFRESHING,
+
+    /**
+     * Error status.
+     */
+    ERROR
 }

--- a/common/src/main/resources/i18n/kakoo-foundation-common.properties
+++ b/common/src/main/resources/i18n/kakoo-foundation-common.properties
@@ -22,3 +22,4 @@ kakoo-foundation-common.resource.bundle.registered                            = 
 kakoo-foundation-common.resource.bundle.replaced                              = Resource bundle [name={0}, locale={2}, entries={3}] has replaced bundle [name={0}, locale={1}]
 kakoo-foundation-common.test.dummy                                            = Un message de test du composant: kakoo-foundation-common
 kakoo-foundation-common.test.dummy.language                                   = English
+kakoo-foundation-common.test.dummy.message.formatted                          = The chosen color is: '%s' and the chosen fruit is: '%s'

--- a/common/src/main/resources/i18n/kakoo-foundation-common_de.properties
+++ b/common/src/main/resources/i18n/kakoo-foundation-common_de.properties
@@ -20,6 +20,6 @@ kakoo-foundation-common.resource.bundle.invalidName                           = 
 kakoo-foundation-common.resource.bundle.notFound                              = Resource bundle [name={0}, locale={1}, fullname={0}_{1}.properties] cannot be found
 kakoo-foundation-common.resource.bundle.registered                            = Resource bundle registered [enum={0}, locale={1}, entries={2}, properties={3}]
 kakoo-foundation-common.resource.bundle.replaced                              = Resource bundle [name={0}, locale={2}, entries={3}] has replaced bundle [name={0}, locale={1}]
-kakoo-foundation-common.test.dummy                                            = Un message de test du composant: kakoo-foundation-common
-kakoo-foundation-common.test.dummy.language                                   = Fran\u00E7ais
-kakoo-foundation-common.test.dummy.message.formatted                          = La couleur choisie est: '%s' et le fruit choisi est: '%s'
+kakoo-foundation-common.test.dummy                                            = Eine Nachricht von der Komponente: kakoo-foundation-common
+kakoo-foundation-common.test.dummy.language                                   = Deutsch
+kakoo-foundation-common.test.dummy.message.formatted                          = Die gewählte Farbe ist: ''{0}'' und die ausgewählte Frucht ist: ''{1}''

--- a/common/src/main/resources/i18n/kakoo-foundation-common_en.properties
+++ b/common/src/main/resources/i18n/kakoo-foundation-common_en.properties
@@ -22,3 +22,4 @@ kakoo-foundation-common.resource.bundle.registered                            = 
 kakoo-foundation-common.resource.bundle.replaced                              = Resource bundle [name={0}, locale={2}, entries={3}] has replaced bundle [name={0}, locale={1}]
 kakoo-foundation-common.test.dummy                                            = Un message de test du composant: kakoo-foundation-common
 kakoo-foundation-common.test.dummy.language                                   = English
+kakoo-foundation-common.test.dummy.message.formatted                          = The chosen color is: '%s' and the chosen fruit is: '%s'

--- a/common/src/test/java/com/kakoo/foundation/common/resource/bundle/test/TestResourceBundleManager.java
+++ b/common/src/test/java/com/kakoo/foundation/common/resource/bundle/test/TestResourceBundleManager.java
@@ -11,9 +11,9 @@
  */
 package com.kakoo.foundation.common.resource.bundle.test;
 
+import com.kakoo.foundation.common.resource.bundle.KakooFoundationCommonBundle;
 import com.kakoo.foundation.common.resource.bundle.ResourceBundleException;
 import com.kakoo.foundation.common.resource.bundle.ResourceBundleManager;
-import com.kakoo.foundation.common.resource.bundle.ResourceBundleManagerException;
 import lombok.extern.log4j.Log4j;
 import org.junit.*;
 
@@ -116,13 +116,13 @@ public final class TestResourceBundleManager
      * Test the cleaning of the resource bundle manager cache.
      */
     @SuppressWarnings({ "static-method", "nls" })
-    @Test(expected = ResourceBundleManagerException.class)
+    @Test(expected = ResourceBundleException.class)
     public final void testClearCache()
     {
-        ResourceBundleManager.register("i18n/kakoo-foundation-common");
-        Assert.assertEquals(getExpectedDummyLanguageValue(), ResourceBundleManager.get("kakoo-foundation-common.test.dummy.language"));
+        ResourceBundleManager.register("i18n/fruits");
+        ResourceBundleManager.get("fruit.apple.name");
         ResourceBundleManager.clear();
-        ResourceBundleManager.get("kakoo-foundation-common.test.dummy.language");
+        ResourceBundleManager.get("fruit.apple.name");
     }
 
     /**
@@ -171,12 +171,6 @@ public final class TestResourceBundleManager
     @Test
     public final void testRetrieveKeyCurrentLocale()
     {
-        String expected;
-
-        // Set the default locale of the JVM.
-        ResourceBundleManager.setLocale(Locale.getDefault());
-
-        ResourceBundleManager.clear();
         ResourceBundleManager.register("i18n/kakoo-foundation-common");
         Assert.assertEquals(getExpectedDummyLanguageValue(), ResourceBundleManager.get("kakoo-foundation-common.test.dummy.language"));
     }
@@ -256,5 +250,59 @@ public final class TestResourceBundleManager
         }
 
         return expected;
+    }
+
+    /**
+     * Test the retrieving of a resource bundle key through enumeration in the current locale.
+     */
+    @SuppressWarnings({ "static-method", "nls" })
+    @Test
+    public final void testRetrieveEnumKeyCurrentLocale()
+    {
+        ResourceBundleManager.clear();
+        String value = ResourceBundleManager.get(KakooFoundationCommonBundle.TEST_DUMMY);
+        String other = KakooFoundationCommonBundle.TEST_DUMMY.getValue();
+    }
+
+    /**
+     * Test the retrieving of a resource bundle key through enumeration in a given locale.
+     */
+    @SuppressWarnings({ "static-method", "nls" })
+    @Test
+    public final void testRetrieveEnumKeyOtherLocale()
+    {
+        String expected = "Eine Nachricht von der Komponente: kakoo-foundation-common";
+
+        ResourceBundleManager.clear();
+        Assert.assertEquals(expected, ResourceBundleManager.get(KakooFoundationCommonBundle.TEST_DUMMY, Locale.GERMAN));
+    }
+
+    /**
+     * Test the retrieving of a resource bundle key through enumeration in a given locale for which the resource
+     * bundle file in the given locale does not exist.
+     * <p>
+     * It should retrieve the value from the default bundle file and should not fail.
+     */
+    @SuppressWarnings({ "static-method", "nls" })
+    @Test
+    public final void testRetrieveEnumKeyOtherLocaleNotExistingBundle()
+    {
+        if (ResourceBundleManager.get(KakooFoundationCommonBundle.TEST_DUMMY, Locale.CHINESE).isEmpty())
+        {
+            fail("Should not be empty!");
+        }
+    }
+
+    /**
+     * Test the retrieving of a resource bundle key through enumeration with message formatting.
+     */
+    @SuppressWarnings({ "static-method", "nls" })
+    @Test
+    public final void testRetrieveEnumKeyCurrentLocaleFormatted()
+    {
+        String expected = "Die gewählte Farbe ist: 'gelb' und die ausgewählte Frucht ist: 'Erdbeere'";
+
+        String message = ResourceBundleManager.get(KakooFoundationCommonBundle.TEST_DUMMY_MESSAGE_FORMATTED, Locale.GERMAN, "gelb", "Erdbeere");
+        Assert.assertEquals(expected, message);
     }
 }


### PR DESCRIPTION
- Resource bundle manager is now able to automatically register bundle files associated with classes annotated with the @Bundle annotation.

- The resource bundle manager is now able to retrieve resource bundle message strings using enumerations.